### PR TITLE
Minor namespace changes for config

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -4,9 +4,9 @@ VERSION = 0.63-dev
 # Customize below to fit your system
 
 # paths
-INSTFOLDER = /usr/share/screen-session
+INSTFOLDER = /usr/local/share/screen-session
 
-PREFIX = /usr
+PREFIX = /usr/local
 
 # includes and libs
 INCS =


### PR DESCRIPTION
Changing references of "/usr" to "/usr/local" which is more standard for packages installed from source, and specifically won't conflict with ubuntu/debian packages.
